### PR TITLE
Create automation for tf-modules sub-directory

### DIFF
--- a/.github/workflows/chart-pr-checks.yaml
+++ b/.github/workflows/chart-pr-checks.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - charts/**
 
 jobs:
   lint-test:

--- a/.github/workflows/tf-module-pr-checks.yaml
+++ b/.github/workflows/tf-module-pr-checks.yaml
@@ -1,0 +1,105 @@
+# PR checks for updates to Terraform modules (tf-modules)
+#
+# TODO: 
+#   Improve outputs so that failed steps show list of files that failed
+#   Add the failure output as comment to PR
+
+name: Terraform Module PR check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - tf-modules/**
+
+jobs:
+  tf-fmt:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout repo'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Run tf fmt'
+        id: "tf-fmt"
+        uses: 'actionshub/terraform-lint@main'
+
+  tflint:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout repo'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Run TFLint'
+        uses: 'devops-infra/action-tflint@master'
+
+  tfsec:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout repo'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Run tfsec'
+        id: 'tfsec'
+        uses: 'triat/terraform-security-scan@v2.2.3'
+
+  version-bumnp-verify:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    # Get list of files changed as part of this merge
+    - name: Get changed files
+      id: changed-files
+      uses: lots0logs/gh-action-get-changed-files@2.1.4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    # process changed file list for any changes to helm charts under the helm directory
+    - name: Create list of updated TF modules from changed file list
+      id: tf-changed-list
+      run: |
+         # process list of changed files
+         changed_files=$(echo "${{ steps.changed-files.outputs.all }}" | tr -d '[|]' | sed -e 's;,; ;g')
+         tf_module_list=()
+         # for each file see if it part of a helm chart
+         for file in ${changed_files}
+         do
+            if echo $file | grep -qE "^tf-modules/"
+            then
+               # file under helm directory get subdir name
+               subdir=$(echo $file | cut -d '/' -f2)
+               # check if we seen this subdir before
+               if [[ ! " ${tf_module_list[@]} " =~ " ${subdir} " ]]
+               then
+                   # add to changed chart list
+                   tf_module_list+=( "${subdir}" )
+               fi
+            fi
+         done
+         # write to file
+         echo "${tf_module_list[@]}" > changed-tf-modules.txt
+         echo "The following Automatic Potato Apps have updates:"
+         cat changed-tf-modules.txt
+
+    - name: Verify that version was bumped
+      run: |
+        failed_tf_modules=()
+        # for each updated AP Apps create release
+        for tf_module in $(cat changed-tf-modules.txt)
+        do
+          if ! grep -q "tf-modules/${tf_module}/VERSION.TXT" <<< "${{ steps.changed-files.outputs.all }}"
+          then
+             failed_tf_modules+=( "${tf_module}" )
+          fi 
+        done
+        if  (( ${#failed_tf_modules[@]} > 0 ))
+        then
+           echo "The following Terraform modules were updated but did not have their VERSION.TXT file updated:"
+           for failed_tf in ${failed_tf_modules}
+           do
+             echo "${failed_tf}"
+           done
+           exit 1
+        fi 

--- a/.github/workflows/tf-module-release.yaml
+++ b/.github/workflows/tf-module-release.yaml
@@ -1,0 +1,63 @@
+name: Automatic-Potato Terraform Module Releaser
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - tf-modules/**
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    # Get list of files changed as part of this merge
+    - name: Get changed files
+      id: changed-files
+      uses: lots0logs/gh-action-get-changed-files@2.1.4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    # process changed file list for any changes to helm charts under the helm directory
+    - name: Create list of Terraform modules that were updated
+      id: tf-changed-list
+      run: |
+         # process list of changed files
+         changed_files=$(echo "${{ steps.changed-files.outputs.all }}" | tr -d '[|]' | sed -e 's;,; ;g')
+         tf_module_list=()
+         # for each file see if it part of a helm chart
+         for file in ${changed_files}
+         do
+            if grep -qE "^tf-modules/" <<< ${file}
+            then
+               # get sub-dir for module name
+               subdir=$(echo $file | cut -d '/' -f2)
+               # check if we seen this subdir before
+               if [[ ! " ${tf_module_list[@]} " =~ " ${subdir} " ]]
+               then
+                   # add to changed chart list
+                   tf_module_list+=( "${subdir}" )
+               fi
+           fi
+         done
+         # write to file
+         echo "${tf_module_list[@]}" > changed-tf-modules.txt
+         echo "The following Automatic Potato Apps have updates:"
+         cat changed-tf-modules.txt
+
+    - name: Create release tags for updated modules
+      run: |
+        #
+        # for each updated AP Apps create release
+        for tf_module in $(cat changed-tf-modules.txt)
+        do
+          # get version from file
+          tfver=$(cat tf-modules/${tf_module}/VERSION.TXT)
+          echo "Creating release tag for TF Module (${tf_module} - version (${tfver}): tf-${tf_module}-${tfver}"
+          git tag tf-${tf_module}-${tfver}
+        done
+        # push tags
+        git push --tags

--- a/.github/workflows/tf-module-release.yaml
+++ b/.github/workflows/tf-module-release.yaml
@@ -1,4 +1,4 @@
-name: Automatic-Potato Terraform Module Releaser
+name: Terraform Module Releaser
 
 on:
   push:


### PR DESCRIPTION
This PR creates two github actions for changes under the new sub-directory: tf-modules

The first is a PR checker that validates TF code by running:
 * terraform fmt
 * terraform linter
 * terraform tfsec
 * ensures that any TF module updated as part of the PR has its VERSION.TXT file updated as part of PR

The second action will automatically create a tag for each TF module that is updated, using the version value in the VERSION.TXT file.  The format of the tag is:  tf-<MODULE-SUB-DIR-NAME>-<VERSION-STRING-FROM-VERSION-FILE>

This PR also renames the current pr check for helm charts to: chart-pr-checks.yaml and updates it to only run when files are changed under the charts/** directory.
