### PR TITLE
New version of nginx chart - BITSDN-199

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -21,10 +21,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.21.0"

--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -15,13 +15,13 @@ A Helm chart for Kubernetes
 
 * Add the BITS Helm charts repo and install the chart
 ```
-helm repo add bits https://broadinstitute.github.io/bits-helm-charts
+helm repo add bits https://broadinstitute.github.io/bits-ap-modules
 helm install nginx bits/nginx
 ```
 
 ## Private Github Repo
 
-* To be able to pull from a private repo, [generate a read-only deploy key](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys) and add it to kubernetes secrets
+* To be able to pull from a private repo, [generate a read-only deploy key](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys) and add it as a reader to the github repo.  You can at this point either manually create a kubernetes secret from these files.
 ```
 kubectl create secret generic --namespace=example-site kubernetes.io/ssh-auth --from-file=ssh-privatekey=/path/to/key --from-file=ssh-publickey=/path/to/key.pub example-deploykey
 ```
@@ -31,6 +31,7 @@ kubectl create secret generic --namespace=example-site kubernetes.io/ssh-auth --
 ssh-privatekey: <key>
 ssh-publickey: <key>
 ```
+OR you can pass the private key contents to helm when the chart is deployed on the kubernetes cluster.
 
 ## Configuration
 
@@ -45,12 +46,14 @@ The following table lists the configurable parameters of the Nginx chart and the
 | `imagePullSecrets` |  | `[]` |
 | `nameOverride` |  | `""` |
 | `fullnameOverride` |  | `""` |
-| `cloneFromGithub.enabled` |  | `true` |
-| `cloneFromGithub.deployKeySecret` |  | `""` |
-| `cloneFromGithub.image.repository` |  | `"us-central1-docker.pkg.dev/infra2-core/containers/github-sync"` |
-| `cloneFromGithub.image.tag` |  | `"latest"` |
-| `cloneFromGithub.image.pullPolicy` |  | `"IfNotPresent"` |
-| `cloneFromGithub.repoToClone` |  | `"git@github.com:broadinstitute/potato-site.git"` |
+| `content.enabled` |  | `true` |
+| `content.SyncImage.repository` |  | `"us-central1-docker.pkg.dev/infra2-core/containers/github-sync"` |
+| `content.SyncImage.tag` |  | `"latest"` |
+| `content.git.deployKeySecret` |  | `""` |
+| `content.git.deployKey` |  | `""` |
+| `content.git.repository` |  | `"git@github.com:broadinstitute/potato-site.git"` |
+| `content.git.branch` |  | `"main"` |
+| `content.volume.size` |  | `"1Gi"` |
 | `serviceAccount.create` |  | `false` |
 | `serviceAccount.annotations` |  | `{}` |
 | `serviceAccount.name` |  | `""` |
@@ -61,7 +64,7 @@ The following table lists the configurable parameters of the Nginx chart and the
 | `service.port` |  | `80` |
 | `ingress.enabled` |  | `false` |
 | `ingress.annotations` |  | `{}` |
-| `ingress.hosts` |  | `[{"host": "chart-example.local", "paths": [{"path": "/", "backend": {"serviceName": "chart-example.local", "servicePort": 80}}]}]` |
+| `ingress.hosts` |  | `[]` |
 | `ingress.tls` |  | `[]` |
 | `resources` |  | `{}` |
 | `autoscaling.enabled` |  | `false` |
@@ -71,9 +74,8 @@ The following table lists the configurable parameters of the Nginx chart and the
 | `nodeSelector` |  | `{}` |
 | `tolerations` |  | `[]` |
 | `affinity` |  | `{}` |
-| `livenessProbe.httpGet.path` |  | `"/"` |
-| `livenessProbe.httpGet.port` |  | `"http"` |
-| `livenessProbe.initialDelaySeconds` |  | `180` |
+| `livenessProbe.tcpSocket.port` |  | `80` |
+| `livenessProbe.initialDelaySeconds` |  | `45` |
 | `livenessProbe.periodSeconds` |  | `20` |
 | `livenessProbe.timeoutSeconds` |  | `5` |
 | `livenessProbe.failureThreshold` |  | `6` |

--- a/charts/nginx/templates/NOTES.txt
+++ b/charts/nginx/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  https://{{ $host.name }}{{ $host.path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/nginx/templates/ingress.yaml
+++ b/charts/nginx/templates/ingress.yaml
@@ -27,15 +27,16 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .name | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
+        {{- $paths := default (list "/") .paths }}
+        {{- range $paths }}
+          - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-          {{- end }}
-    {{- end }}
+              servicePort: 80
+        {{- end }}
   {{- end }}
+{{- end }}

--- a/charts/nginx/templates/pvc.yaml
+++ b/charts/nginx/templates/pvc.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.deploy.statefulSet }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "nginx.fullname" . }}
+  labels:
+    {{- include "nginx.labels" . | nindent 4 }}
+spec:
+  storageClassName: "standard-rwo"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.content.volume.size }}
+{{- end }}

--- a/charts/nginx/templates/secret.yaml
+++ b/charts/nginx/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.content.git.deployKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nginx.fullname" . }}
+  labels:
+    {{- include "nginx.labels" . | nindent 4 }}
+type: kubernetes.io/ssh-auth
+data:
+  ssh-privatekey: {{ .Values.content.git.deployKey | quote }}
+{{ end }}

--- a/charts/nginx/templates/stateful.yaml
+++ b/charts/nginx/templates/stateful.yaml
@@ -1,21 +1,27 @@
-{{- if not .Values.deploy.statefulSet }}
+{{- if .Values.deploy.statefulSet }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "nginx.fullname" . }}
   labels:
     {{- include "nginx.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "nginx.fullname" . }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "nginx.selectorLabels" . | nindent 6 }}
-  {{- if .Values.strategy }}
-  strategy:
-  {{- toYaml .Values.strategy | nindent 4 }}  
-  {{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage:  {{ .Values.content.volume.size }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -123,9 +129,6 @@ spec:
       volumes:
       - name: local-www
         emptyDir: {}
-      - name: www
-        persistentVolumeClaim:
-          claimName: {{ include "nginx.fullname" . }}
       {{- if or .Values.content.git.deployKey .Values.content.git.deploySecret }}
       - name: idrsa
         secret:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -2,7 +2,16 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+deploy:
+  statefulSet: false
+
+# with PDs stategy must be ReCreate so that PD is released from pod before new pod
+#  is started
+strategy:
+  type: ReCreate
+
+# to ensure no downtime upon updates replicacount is 2
+replicaCount: 2
 
 image:
   repository: nginx
@@ -14,15 +23,31 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-cloneFromGithub:
+content:
   enabled: true
-  # deployKeySecret must be key-value pair with key of "ssh-privatekey".
-  deployKeySecret: ""
-  image:
-    repository: us-central1-docker.pkg.dev/infra2-core/containers/github-sync
-    tag: latest
+  # how often does sync wait in between sync runs
+  sleep_time: 300
+  # bash shell issue the following is a string NOT boolean so must have quotes
+  loop_forever: "true"
+  # path inside content location where web content is stored - defaults to top-level content storage
+  path: ""
+  SyncImage:
+    repository: us-docker.pkg.dev/infra2-core/containers/gitcloner
     pullPolicy: IfNotPresent
-  repoToClone: git@github.com:broadinstitute/potato-site.git
+    tag: 1.0
+    command:
+    args: []
+  git:
+    repository:
+    branch: "main"
+    # If it is a private repo must provide either the deployKey value or the name
+    #  of an existing kubernetes secret that contains the key
+    deployKey:
+    deploySecret:
+  gcs:
+    bucket:
+  volume:
+    size: 1Gi
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -54,13 +79,13 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-      - path: /
-        backend:
-          serviceName: chart-example.local
-          servicePort: 80
+  hosts: []
+#    - name: chart-example.local
+#      paths:
+#      - path: /
+#        backend:
+#          serviceName: chart-example.local
+#          servicePort: 80
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
@@ -94,11 +119,11 @@ affinity: {}
 ## NGINX containers' liveness and readiness probes.
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 ##
+# Liveness probe should be as lightweight as possible
 livenessProbe:
-  httpGet:
-    path: "/"
-    port: http
-  initialDelaySeconds: 180
+  tcpSocket:
+    port: 80
+  initialDelaySeconds: 45
   periodSeconds: 20
   timeoutSeconds: 5
   failureThreshold: 6


### PR DESCRIPTION
Somewhat of a re-work of previous.  The changes include:
 - Removing the gitcloner init container and creating a sidecar running a loop to keep content up to date
 - Storing content on a PD instead of host volume.  General good practice to not consume too much disk resources on node-pool hosts
 - Enabling stateful set which is the recommended if a pod is using a PD
 - Allows passing in deployKey secret on helm install
